### PR TITLE
adding age group at ART initiation to BMI outputs

### DIFF
--- a/config/test.yaml
+++ b/config/test.yaml
@@ -6,15 +6,15 @@ comorbidity_flag: 1 # 0, 1
 new_dx: 'base' # base, ehe, sa
 mortality_model: 'by_sex_race_risk' # by_sex_race_risk, by_sex_race, by_sex, overall
 mortality_threshold_flag: 1 # 0, 1:
-final_year: 2020 # [2010 - 2035]
-verbose: 0 #0, 1
+final_year: 2012 # [2010 - 2035]
+verbose: 1 #0, 1
 sa_type: 'none' # none, type1, type2, aim2_inc, aim2_prev, aim2_mort
 idu_threshold: '2x' # 2x, 5x, 10x
 
 
-bmi_intervention: 1  #0 is no intervention, 1 is basic scenario
-bmi_intervention_scenario: 1
-bmi_intervention_start_year: 2010
-bmi_intervention_end_year: 2030
+bmi_intervention: 1  #0: skipping intervention and data collection, 1 data will be collected
+bmi_intervention_scenario: 1 # 0 placebo arm, 1 bmi maintenance at 29.9, 2 bmi gain restricted at 5%, 3 no bmi gain
+bmi_intervention_start_year: 2012
+bmi_intervention_end_year: 2021
 bmi_intervention_coverage: 1.0 # [0.0 - 1.0]
 bmi_intervention_effectiveness: 1.0 # [0.0 - 1.0]


### PR DESCRIPTION
renamed bmi_int_coverage output to bmi_int_cascade. 
I also added count by agegroup at ART initiation to both outputs.
the bmi_int_cascade include all the outputs that we are collecting for the bmi intervention